### PR TITLE
added a method to convert to HTML5 from an existing TEI DOM

### DIFF
--- a/src/CETEI.js
+++ b/src/CETEI.js
@@ -62,6 +62,13 @@ class CETEI {
     makeHTML5(TEI, callback, perElementFn){
       // TEI is assumed to be a string
       let TEI_dom = ( new DOMParser() ).parseFromString(TEI, "text/xml");
+      this.domToHTML5(TEI_dom, callback, perElementFn);
+    }
+
+    /* Converts the supplied TEI DOM into HTML5 Custom Elements. If a callback
+       function is supplied, calls it on the result.
+    */
+    domToHTML5(TEI_dom, callback, perElementFn){
 
       this._fromTEI(TEI_dom);
 


### PR DESCRIPTION
Over at the Brown library, we're using CETEIcean to display a collection of inscriptions (encoded in EpiDoc) for proofreading and display. The demo is here: https://brown-university-library.github.io/iip-texts/?id=caes0122#

I wanted to be able to show the exact source of the transcription (EpiDoc markup) alongside the display version (Leiden-ish), so that encoders could identify their mistakes, and didn't want to parse the XML twice, so I refactored the makeHTML5 function to accept a pre-existing DOM and renamed it domToHTML5 to preserve the existing API in a separate function. This seemed like it might be of interest to more people than just me!

Happy to change the name or block comments.