### PR TITLE
added support for rtl languages

### DIFF
--- a/test/CETEIcean.css
+++ b/test/CETEIcean.css
@@ -1,4 +1,23 @@
-
+/* language support */
+/* render Arabic, Persian, Ottoman, Hebrew  as rtl */
+[lang = "ar"],
+[lang = "ota"],
+[lang = "fa"],
+[lang = "he"],
+[lang *="-Arab-AR"]{
+    direction:rtl;
+    text-align:right;
+}
+/* display latin scripts as ltr  */
+[lang = "en"],
+[lang = "fr"],
+[lang = "de"],
+[lang = "it"],
+[lang *="ar-Latn-"],
+[lang *="ota-Latn-"]{
+    direction:ltr;
+    text-align:left;
+}
 
 /* Choice elements */
 tei-choice tei-abbr + tei-expan:before,


### PR DESCRIPTION
I added a few lines of CSS to support the correct display of right-to-left scripts such as Arabic and Hebrew using values of the `@xml:lang` attribute.