### PR TITLE
Behavior functions are being called with the wrong `this`.

### DIFF
--- a/src/CETEI.js
+++ b/src/CETEI.js
@@ -292,9 +292,9 @@ decorator(template) {
     for (let rule of template) {
       if (elt.matches(rule[0]) || rule[0] === "_") {
         if (Array.isArray(rule[1])) {
-          return self.decorator(rule[1]).call(this, elt);
+          return self.decorator(rule[1]).call(self, elt);
         } else {
-          return rule[1].call(this, elt);
+          return rule[1].call(self, elt);
         }
       }
     }


### PR DESCRIPTION
This breaks behaviors that assume that their `this` is `CETEI`;
there is one like that in `defaultBehavoirs`: endnotes.

(This will auto-fix in ``/tutorial/js/CETEI.js` once results of the `npm` build are checked in - which seems to have not been happening for a while in `/tutorial`...)