### PR TITLE
Trims URL argument before rewriting

### DIFF
--- a/src/utilities.js
+++ b/src/utilities.js
@@ -144,8 +144,8 @@ export function getPrefixDef(prefix) {
   HTML document
 */
 export function rw(url) {
-  if (!url.match(/^(?:http|mailto|file|\/|#).*$/)) {
-    return this.base + first(url);
+  if (!url.trim().match(/^(?:http|mailto|file|\/|#).*$/)) {
+    return this.base + first(url.trim());
   } else {
     return url;
   }


### PR DESCRIPTION
## In this PR

This PR adds a small tweak to the `rw(url)` utility method. The URL argument is now trimmed before the RegEx check that determines whether the URL should be re-written from a relative to an absolute URL. (If it is re-written, trim is also applied.)

Addresses issue #67.