### PR TITLE
Accessibility improvements

### DIFF
--- a/src/CETEI.js
+++ b/src/CETEI.js
@@ -41,6 +41,7 @@ class CETEI {
     this.prefixDefs = [];
     this.debug = this.options.debug === true ? true : false;
     this.discardContent = this.options.discardContent === true ? true : false;
+    this.addMainRole = this.options.omitMainRole === true ? false : true;
 
     if (this.options.base) {
       this.base = this.options.base;
@@ -197,14 +198,10 @@ class CETEI {
           "replacementPattern": el.getAttribute("replacementPattern")
         };
       }
-      // Aria roles for landmark elements
-      if (el.localName == "TEI") {
+      // Aria main landmark for the TEI root (can be disabled via the omitMainRole option)
+      if (el.localName == "TEI" && this.addMainRole) {
         newElement.setAttribute("role", "main");
       }
-      if (["body", "front", "back", "div"].includes(el.localName)) {
-        newElement.setAttribute("role", "region");
-        newElement.setAttribute("aria-label", el.getAttribute("xml:id") || el.getAttribute("n") || el.localName);
-      } 
       for (let node of Array.from(el.childNodes)) {
           // Node.ELEMENT_NODE
           if (node.nodeType == 1 ) {

--- a/src/defaultBehaviors.js
+++ b/src/defaultBehaviors.js
@@ -79,6 +79,16 @@ export default {
       }],
       ["_", ["(",")"]]
     ],
+    // Renders <head> as a semantic HTML heading (h1–h6) for accessibility
+    "head": function(elt) {
+      const doc = elt.ownerDocument;
+      const level = Number(elt.getAttribute("data-level")) || 1;
+      let heading = doc.createElement("h" + Math.min(Math.max(level, 1), 6));
+      for (let node of Array.from(elt.childNodes)) {
+        heading.appendChild(node.cloneNode(true));
+      }
+      return heading;
+    },
     // Hide the teiHeader by default
     "teiHeader": function(e) {
       this.hideContent(e, false);

--- a/test/CETEIcean.css
+++ b/test/CETEIcean.css
@@ -346,6 +346,10 @@ tei-head {
   font-family: Arvo, sans-serif;
   font-weight: normal;
 }
+tei-head > :is(h1, h2, h3, h4, h5, h6) {
+  font: inherit;
+  margin: 0;
+}
 tei-body > tei-head {
   font-size: 180%;
   text-indent: -0.5em;


### PR DESCRIPTION
1. Removed awkward roles and aria-labels. Identifying tei-div as a region is overkill (html:divs are not landmarks) and using aria-label="div" would cause a screen reader to announce every div as "div, div, div, div...."
2. parametrized role=main. CETEIcean isn't always used as standalone and there may be an html:main already. I kept it as default but it can be turned off.
3.  Added a default behavior and CSS for headings using HTML elements. tei-heads are now rendered as html h1, h2, etc based on the computed data-level. This satisfies WCAG AA compliance for headers.